### PR TITLE
fix(#):  Fix typo in enum variant name

### DIFF
--- a/src/upload/result.rs
+++ b/src/upload/result.rs
@@ -25,7 +25,7 @@ pub struct Message {
 #[derive(Clone, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum UploadResult {
-    Succes(Box<Response>),
+    Success(Box<Response>),
     Error(Box<Error>),
 }
 


### PR DESCRIPTION
In this commit, the typo in the "Success" variant of the enum has been corrected to "Success".




